### PR TITLE
NPM install used wrong name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,10 @@
 
 # SentiMental - Putting the Mental in Sentimental
       
-  Sentiment analysis tool for node.js based on the AFINN-111 wordlist. http://www2.imm.dtu.dk/pubdb/views/publication_details.php?id=6010
+  Sentiment analysis tool for node.js based on the [AFINN-111 wordlist](http://www2.imm.dtu.dk/pubdb/views/publication_details.php?id=6010).
   
 ## Install
-    $ npm install sentimental
+    $ npm install Sentimental
 
 ## Features
 


### PR DESCRIPTION
When trying to install via "npm install sentimental" it fails. Must use "npm install Sentimental."
