### PR TITLE
Updated noPunctuation regexes to allow for hypens

### DIFF
--- a/lib/sentimental.js
+++ b/lib/sentimental.js
@@ -1,6 +1,5 @@
 var afinn = require('../wordLists/afinn.json');
 
-
 // Calculates the negative sentiment of a sentence
 // -------------------------------------------------- //
 
@@ -9,8 +8,8 @@ function negativity (phrase) {
     hits -= score;
     words.push(t);
   };
-    
-  var noPunctuation = phrase.replace(/[^a-zA-Z ]+/g, ' ').replace('/ {2,}/',' '),
+
+  var noPunctuation = phrase.replace(/[^a-zA-Z0 -]+/g, ' ').replace('/ {2,}/',' '),
       tokens = noPunctuation.toLowerCase().split(" "),
       hits   = 0,
       words  = [];
@@ -40,7 +39,7 @@ function positivity (phrase) {
     words.push(t);
   };
 
-  var noPunctuation = phrase.replace(/[^a-zA-Z ]+/g, ' ').replace('/ {2,}/',' '),
+  var noPunctuation = phrase.replace(/[^a-zA-Z -]+/g, ' ').replace('/ {2,}/',' '),
       tokens = noPunctuation.toLowerCase().split(" "),
       hits   = 0,
       words  = [];

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,14 @@ describe('Negativity', function () {
       negativity("I'll be here till 5").score.should.equal(0);
       done();
     });
+    it('should properly handle hyphenated words', function (done) {
+      negativity("you are self-deluded").score.should.equal(2);
+      done();
+    });
+    it('should properly handle n00b (the only word in the AFINN list with a number)', function (done) {
+      negativity("you are a n00b").score.should.equal(2);
+      done();
+    });
   });
 });
 
@@ -86,6 +94,11 @@ describe('Positivity', function () {
   describe('#positiveComparative', function () {
     it('should properly handle punctuation', function (done) {
       positivity("I'll be here till 5").score.should.equal(0);
+      done();
+    });
+
+    it('should properly handle hyphenated words', function (done) {
+      positivity("it was a once-in-a-lifetime day").score.should.equal(3);
       done();
     });
   });


### PR DESCRIPTION
Updated the noPunctuation regexes for positivity and negativity to allow
for hypens so that the 8 hyphenated words in the AFINN list.

Also updated the regex to match the number 0 so that "n00b", the only
word in the list that contains a number is also matched.

This addresses issue #11.
